### PR TITLE
最新バージョンを使用するとエラーとなる箇所があるためバージョンを固定

### DIFF
--- a/book/source/auth/frontend/routing/README.md
+++ b/book/source/auth/frontend/routing/README.md
@@ -22,7 +22,7 @@ React Routerを使用することで、URLごとに使用するコンポーネ�
 React RouterとTypeScript用の型定義をインストールするため、`frontend`ディレクトリで次のコマンドを実行します。（参考：[Installation | React Router](https://reactrouter.com/web/guides/quick-start#quick-start-installation)）
 
 ```
-npm install --save react-router-dom @types/react-router-dom
+npm install --save react-router-dom@5 @types/react-router-dom@5
 ```
 
 ## ルーティングの設定

--- a/example/todo-app/frontend/docker/docker-compose.api-gen.yml
+++ b/example/todo-app/frontend/docker/docker-compose.api-gen.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   openapi-gen:
-    image: openapitools/openapi-generator-cli
+    image: openapitools/openapi-generator-cli:v5.4.0
     volumes:
       - ../..:/todo-app
     command: generate -g typescript-fetch -i /todo-app/backend/rest-api-specification/openapi.yaml -o /todo-app/frontend/src/backend/generated-rest-client --additional-properties supportsES6=true,typescriptThreePlus=true

--- a/starter-kit/frontend/docker/docker-compose.api-gen.yml
+++ b/starter-kit/frontend/docker/docker-compose.api-gen.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   openapi-gen:
-    image: openapitools/openapi-generator-cli
+    image: openapitools/openapi-generator-cli:v5.4.0
     volumes:
       - ../..:/todo-app
     command: generate -g typescript-fetch -i /todo-app/backend/rest-api-specification/openapi.yaml -o /todo-app/frontend/src/backend/generated-rest-client --additional-properties supportsES6=true,typescriptThreePlus=true


### PR DESCRIPTION
以下の対応を実施しました。

- OpenAPI GeneratorのDockerイメージは最新の`v6`系を使用するとエラーになるため、`v5`系に固定
- ReactRouterは最新の`v6`系を使うとエラーになるため、`v5`系に固定