### PR TITLE
✨: リンク切れを検知するためにhtmltestを導入

### DIFF
--- a/book/.htmltest.yaml
+++ b/book/.htmltest.yaml
@@ -1,0 +1,14 @@
+# wjdp/htmltest
+
+# 実行方法
+# docker run -v (pwd)/_book:/test/_book -v (pwd)/.htmltest.yaml:/test/.htmltest.yaml --rm wjdp/htmltest --conf .htmltest.yaml
+
+# https://github.com/wjdp/htmltest#wrench-configuration
+DirectoryPath: _book
+# 末尾にスラッシュのないディレクトリへのリンクがエラーになってしまう
+IgnoreDirectoryMissingTrailingSlash: true
+IgnoreURLs:
+  - localhost:3000
+  - localhost:9080
+# 余裕を持って長めに設定しておく。
+ExternalTimeout: 60

--- a/book/source/auth/backend/README.md
+++ b/book/source/auth/backend/README.md
@@ -20,6 +20,6 @@
 
 ログイン状態によるREST APIへのアクセス制御を実装します。
 
-## [ToDo管理でのユーザー取得](auth/backend/todo/README.md)
+## [ToDo管理でのユーザー取得](todo/README.md)
 
 ToDo管理のREST APIで、ログインしたユーザーを使用するように修正します。

--- a/book/source/todo/backend/todo-list/README.md
+++ b/book/source/todo/backend/todo-list/README.md
@@ -4,7 +4,7 @@ ToDoの一覧を取得するために使用するREST APIを実装します。
 
 ## OpenAPIドキュメントの確認
 
-バックエンドのREST APIは、OpenAPIドキュメントの定義と合うように実装しますので、OpenAPIドキュメントを確認します。フロントエンドのREST APIクライアント作成で説明している内容と同じであるため、該当ページの「[OpenAPIドキュメントの確認](../../frontend/api/README.md#OpenAPIドキュメントの確認)」を参照してください。
+バックエンドのREST APIは、OpenAPIドキュメントの定義と合うように実装しますので、OpenAPIドキュメントを確認します。フロントエンドのREST APIクライアント作成で説明している内容と同じであるため、該当ページの「[OpenAPIドキュメントの確認](../../frontend/api/README.md#openapiドキュメントの確認)」を参照してください。
 
 ## ダミーデータのToDoを取得する処理の実装
 


### PR DESCRIPTION
## 実施したこと

- [x] リンク切れを検知するために[htmltest](https://github.com/wjdp/htmltest)を導入
- [x] 検知したリンク切れを修正

## 実行方法

`book`ディレクトリで、以下のコマンドを実行
```bash
docker run -v (pwd)/_book:/test/_book -v (pwd)/.htmltest.yaml:/test/.htmltest.yaml --rm wjdp/htmltest --conf .htmltest.yaml
```