### PR TITLE
🧑‍💻: cloc によるコード行数カウント対象外ファイルの追加

### DIFF
--- a/.clocignore
+++ b/.clocignore
@@ -1,0 +1,16 @@
+########################################################
+# cloc によるコード行数カウントの除外path
+# 使い方
+# cloc [path] --exclude-list-file=.clocignore --vcs=git
+# ※ "--vcs=git" オプションを使うことで .gitignore が考慮されるので、gitignoreしているものは書く必要はない
+
+## 参考: https://github.com/AlDanial/cloc/issues/49
+########################################################
+
+
+# 100%見ない訳では無いが、これを含めると大きくなりすぎる
+example/todo-app/frontend/package-lock.json
+starter-kit/frontend/package-lock.json
+
+# 自動生成コード
+example/todo-app/frontend/src/backend/generated-rest-client


### PR DESCRIPTION
## 概要

- [x] `.clocignore`の追加
  - 設定は一旦`frontend`分のみ

## 実行方法

```bash
cloc example/todo-app/frontend --exclude-list-file=.clocignore --vcs=git
cloc starter-kit/frontend --exclude-list-file=.clocignore --vcs=git
```